### PR TITLE
upgrade web-console to prevent `uninitialized constant Mime::HTML` error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ end
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
-  gem 'web-console', '~> 2.0'
+  gem 'web-console', '~> 3.5.1'
   gem 'travis', '~> 1.8.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,8 +74,7 @@ GEM
       aws-sdk-core (= 2.3.22)
     backports (3.10.3)
     bcrypt (3.1.12)
-    binding_of_caller (0.7.3)
-      debug_inspector (>= 0.0.1)
+    bindex (0.5.0)
     bourbon (4.2.0)
       sass (~> 3.4)
       thor
@@ -111,7 +110,6 @@ GEM
     ddtrace (0.17.2)
       msgpack
       opentracing (>= 0.4.1)
-    debug_inspector (0.0.3)
     delayed_job (4.1.3)
       activesupport (>= 3.0, < 5.2)
     delayed_job_active_record (4.1.2)
@@ -382,11 +380,11 @@ GEM
     unicode-display_width (1.4.0)
     warden (1.2.7)
       rack (>= 1.0)
-    web-console (2.3.0)
-      activemodel (>= 4.0)
-      binding_of_caller (>= 0.7.2)
-      railties (>= 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
+    web-console (3.5.1)
+      actionview (>= 5.0)
+      activemodel (>= 5.0)
+      bindex (>= 0.4.0)
+      railties (>= 5.0)
     webmock (3.3.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -452,7 +450,7 @@ DEPENDENCIES
   travis (~> 1.8.0)
   turbolinks
   uglifier (>= 1.3.0)
-  web-console (~> 2.0)
+  web-console (~> 3.5.1)
   with_transactional_lock
 
 BUNDLED WITH


### PR DESCRIPTION
https://github.com/rails/rails/issues/29408

### Summary

```
mealpalan:test_track(master)$ rails s
=> Booting Puma
=> Rails 5.1.6.1 application starting in development
=> Run `rails server -h` for more startup options
Puma 2.16.0 starting...
* Min threads: 0, max threads: 16
* Environment: development
* Listening on tcp://localhost:3000
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] Started GET "/" for ::1 at 2019-03-01 17:24:19 -0500
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188]    (1.9ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188]
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] ActiveRecord::PendingMigrationError (

Migrations are pending. To resolve this issue, run:

        bin/rails db:migrate RAILS_ENV=development

):
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188]
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] activerecord (5.1.6.1) lib/active_record/migration.rb:576:in `check_pending!'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] activerecord (5.1.6.1) lib/active_record/migration.rb:553:in `call'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] actionpack (5.1.6.1) lib/action_dispatch/middleware/callbacks.rb:26:in `block in call'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] activesupport (5.1.6.1) lib/active_support/callbacks.rb:97:in `run_callbacks'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] actionpack (5.1.6.1) lib/action_dispatch/middleware/callbacks.rb:24:in `call'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] actionpack (5.1.6.1) lib/action_dispatch/middleware/executor.rb:12:in `call'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] airbrake (7.3.5) lib/airbrake/rack/middleware.rb:48:in `call'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] actionpack (5.1.6.1) lib/action_dispatch/middleware/debug_exceptions.rb:59:in `call'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] web-console (2.3.0) lib/web_console/middleware.rb:28:in `block in call'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] web-console (2.3.0) lib/web_console/middleware.rb:18:in `catch'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] web-console (2.3.0) lib/web_console/middleware.rb:18:in `call'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] actionpack (5.1.6.1) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] railties (5.1.6.1) lib/rails/rack/logger.rb:36:in `call_app'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] railties (5.1.6.1) lib/rails/rack/logger.rb:24:in `block in call'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] activesupport (5.1.6.1) lib/active_support/tagged_logging.rb:69:in `block in tagged'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] activesupport (5.1.6.1) lib/active_support/tagged_logging.rb:26:in `tagged'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] activesupport (5.1.6.1) lib/active_support/tagged_logging.rb:69:in `tagged'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] railties (5.1.6.1) lib/rails/rack/logger.rb:24:in `call'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] actionpack (5.1.6.1) lib/action_dispatch/middleware/remote_ip.rb:79:in `call'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] actionpack (5.1.6.1) lib/action_dispatch/middleware/request_id.rb:25:in `call'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] rack (2.0.6) lib/rack/method_override.rb:22:in `call'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] rack (2.0.6) lib/rack/runtime.rb:22:in `call'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] rack-timeout (0.4.2) lib/rack/timeout/core.rb:122:in `block in call'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] rack-timeout (0.4.2) lib/rack/timeout/support/timeout.rb:19:in `timeout'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] rack-timeout (0.4.2) lib/rack/timeout/core.rb:121:in `call'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] actionpack (5.1.6.1) lib/action_dispatch/middleware/executor.rb:12:in `call'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] actionpack (5.1.6.1) lib/action_dispatch/middleware/static.rb:125:in `call'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] rack (2.0.6) lib/rack/sendfile.rb:111:in `call'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] railties (5.1.6.1) lib/rails/engine.rb:522:in `call'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] puma (2.16.0) lib/puma/server.rb:557:in `handle_request'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] puma (2.16.0) lib/puma/server.rb:404:in `process_client'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] puma (2.16.0) lib/puma/server.rb:270:in `block in run'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188] puma (2.16.0) lib/puma/thread_pool.rb:106:in `block in spawn_thread'
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188]   Rendering /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.1.6.1/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb within rescues/layout
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188]   Rendering /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.1.6.1/lib/action_dispatch/middleware/templates/rescues/_source.html.erb
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188]   Rendered /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.1.6.1/lib/action_dispatch/middleware/templates/rescues/_source.html.erb (1.4ms)
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188]   Rendering /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.1.6.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188]   Rendered /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.1.6.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (1.5ms)
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188]   Rendering /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.1.6.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188]   Rendered /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.1.6.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (0.8ms)
[localhost] [7640e449-056c-4a40-aa05-b7dc77e44188]   Rendered /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.1.6.1/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb within rescues/layout (306.1ms)

NameError: uninitialized constant Mime::HTML
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/web-console-2.3.0/lib/web_console/middleware.rb:58:in `acceptable_content_type?'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/web-console-2.3.0/lib/web_console/middleware.rb:36:in `block in call'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/web-console-2.3.0/lib/web_console/middleware.rb:18:in `catch'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/web-console-2.3.0/lib/web_console/middleware.rb:18:in `call'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.1.6.1/lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.1.6.1/lib/rails/rack/logger.rb:36:in `call_app'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.1.6.1/lib/rails/rack/logger.rb:24:in `block in call'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.1.6.1/lib/active_support/tagged_logging.rb:69:in `block in tagged'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.1.6.1/lib/active_support/tagged_logging.rb:26:in `tagged'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.1.6.1/lib/active_support/tagged_logging.rb:69:in `tagged'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.1.6.1/lib/rails/rack/logger.rb:24:in `call'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.1.6.1/lib/action_dispatch/middleware/remote_ip.rb:79:in `call'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.1.6.1/lib/action_dispatch/middleware/request_id.rb:25:in `call'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rack-2.0.6/lib/rack/method_override.rb:22:in `call'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rack-2.0.6/lib/rack/runtime.rb:22:in `call'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rack-timeout-0.4.2/lib/rack/timeout/core.rb:122:in `block in call'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rack-timeout-0.4.2/lib/rack/timeout/support/timeout.rb:19:in `timeout'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rack-timeout-0.4.2/lib/rack/timeout/core.rb:121:in `call'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.1.6.1/lib/action_dispatch/middleware/executor.rb:12:in `call'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.1.6.1/lib/action_dispatch/middleware/static.rb:125:in `call'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rack-2.0.6/lib/rack/sendfile.rb:111:in `call'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.1.6.1/lib/rails/engine.rb:522:in `call'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/puma-2.16.0/lib/puma/server.rb:557:in `handle_request'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/puma-2.16.0/lib/puma/server.rb:404:in `process_client'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/puma-2.16.0/lib/puma/server.rb:270:in `block in run'
	from /Users/norton/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/puma-2.16.0/lib/puma/thread_pool.rb:106:in `block in spawn_thread'
```